### PR TITLE
Minor fix: use .GetAwaiter.GetResult to avoid AggregateException

### DIFF
--- a/Lagrange.Core/Internal/Context/PacketContext.cs
+++ b/Lagrange.Core/Internal/Context/PacketContext.cs
@@ -46,13 +46,13 @@ internal class PacketContext : ContextBase
             {
                 var sso = SsoPacker.Build(packet, AppInfo, DeviceInfo, Keystore, _signProvider);
                 var service = ServicePacker.BuildProtocol12(sso, Keystore);
-                bool _ = Collection.Socket.Send(service.ToArray()).Result;
+                bool _ = Collection.Socket.Send(service.ToArray()).GetAwaiter().GetResult();
                 break;
             }
             case 13:
             {
                 var service = ServicePacker.BuildProtocol13(packet.Payload, Keystore, packet.Command, packet.Sequence);
-                bool _ = Collection.Socket.Send(service.ToArray()).Result;
+                bool _ = Collection.Socket.Send(service.ToArray()).GetAwaiter().GetResult();
                 break;
             }
         }


### PR DESCRIPTION
Really excited to see dotnet projects of NTQQ&OneBot, fix some minor things while going through codes.